### PR TITLE
DynamoDB: Add ability to define migration table name and meta data

### DIFF
--- a/joplin.dynamodb/src/joplin/dynamodb/database.clj
+++ b/joplin.dynamodb/src/joplin/dynamodb/database.clj
@@ -6,9 +6,10 @@
             [ragtime.protocols :refer [DataStore]]
             [taoensso.faraday :as far]))
 
+
 (defn- ensure-migration-schema
-  [client]
-  (far/ensure-table client :migrations
+  [client migration-table]
+  (far/ensure-table client migration-table
                     [:id :s]
                     {:throughput {:read 1 :write 1}
                      :block?     true}))
@@ -16,24 +17,26 @@
 ;; ============================================================================
 ;; Ragtime interface
 
-(defrecord DynamoDatabase [access-key secret-key endpoint]
-    DataStore
+(defrecord DynamoDatabase [access-key secret-key endpoint migration-table]
+  DataStore
   (add-migration-id [db id]
-    (ensure-migration-schema db)
-    (far/put-item db :migrations
+    (ensure-migration-schema db migration-table)
+    (far/put-item db migration-table
                   {:id         id
                    :created-at (tc/to-long (t/now))}))
   (remove-migration-id [db id]
-    (ensure-migration-schema db)
-    (far/delete-item db :migrations {:id id}))
+    (ensure-migration-schema db migration-table)
+    (far/delete-item db migration-table {:id id}))
   (applied-migration-ids [db]
-    (ensure-migration-schema db)
-    (->> (far/scan db :migrations)
+    (ensure-migration-schema db migration-table)
+    (->> (far/scan db migration-table)
          (sort-by :created-at)
          (map :id))))
 
 (defn- ->DynamoDatabase [target]
-  (map->DynamoDatabase (select-keys (:db target) [:access-key :secret-key :endpoint])))
+  (map->DynamoDatabase (-> (:db target)
+                           (select-keys [:access-key :secret-key :endpoint :migration-table :meta])
+                           (update :migration-table #(or % :migrations)))))
 
 ;; ============================================================================
 ;; Joplin interface


### PR DESCRIPTION
DynamoDB doesn't have a concept of individual databases or name/key-spaces at the account level which means if you're running multiple applications on a single account then you need your own convention for defining table names. When using joplin.dynamodb, using a single 'migrations' clearly means that applications will interfere with one another so this PR introduces a mechanism by which the migrations table name can be specified; for example, app-a-migrations,app-b-migrations` etc.

Also, we can now use a meta field to store custom data that will be bubbled to up and down migration functions.

An example Joplin.edn 'database' field would be:

```edn
:db-staging 
  {:type :dynamo
   :endpoint "http://dynamodb.eu-central-1.amazonaws.com"
   :meta {:custom-field "test"}
   :migration-table "my-application-staging-migrations"}
```